### PR TITLE
fix: pr linting rules subject-case was too strict

### DIFF
--- a/.github/commitlint.config.mjs
+++ b/.github/commitlint.config.mjs
@@ -10,6 +10,7 @@ export default {
         'controller-container',
         'guacamole-chart',
         'guacamole-crds-chart'
-    ]]
+    ]],
+    'subject-case': [RuleConfigSeverity.Error, 'never', []],
   }
 };


### PR DESCRIPTION
## :construction: Suggest a change

Adjust the linting rules for pr titles to allow the subject-case to be more accepting.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
