### PR TITLE
fix: pr-title-lint should run on pr sync so that it's there for required checks

### DIFF
--- a/.github/workflows/pr-title-commitlint.yaml
+++ b/.github/workflows/pr-title-commitlint.yaml
@@ -7,6 +7,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## :construction: Suggest a change

Small fix to pr-title-lint event triggers.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
